### PR TITLE
Update certifi version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://mobile.regulaforensics.com",
     keywords=["face recognition", "facesdk", "regulaforensics", "regula",],
     install_requires=[
-        "certifi==2022.6.15.1",
+        "certifi>=2022.12.7",
         "future==0.18.2",
         "python-dateutil==2.8.1",
         "six==1.15.0",


### PR DESCRIPTION
Versions before 2022.12.7 include some untrustworthy certificates. See: https://pyup.io/v/52365/f17/