### PR TITLE
fix: update trivy-action from @master to @v0.35.0

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run Trivy vulnerability scanner in fs mode
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         scan-type: 'fs'
         exit-code: '1'


### PR DESCRIPTION
## Summary

Pin `aquasecurity/trivy-action` from the floating `@master` tag to the stable `@v0.35.0` release.

## Changes

- `.github/workflows/trivy-scan.yaml`: `aquasecurity/trivy-action@master` → `aquasecurity/trivy-action@v0.35.0`

## Motivation

Using `@master` means the action can change at any time without notice, potentially breaking CI or introducing unexpected behavior. Pinning to a specific version ensures reproducible and predictable builds.

## Ticket

https://redmine.regulaforensics.com/issues/54074